### PR TITLE
extract canGoNext to arrow and helper

### DIFF
--- a/src/arrows.js
+++ b/src/arrows.js
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import classnames from 'classnames';
+import Helpers from './mixins/helpers';
 
 export var PrevArrow = React.createClass({
 
@@ -47,23 +48,10 @@ export var NextArrow = React.createClass({
     var nextClasses = {'slick-arrow': true, 'slick-next': true};
     var nextHandler = this.clickHandler.bind(this, {message: 'next'});
 
-    if (!this.props.infinite) {
-      if (this.props.centerMode) {
-        // check if current slide is last slide
-        if (this.props.currentSlide >= (this.props.slideCount - 1)) {
-          nextClasses['slick-disabled'] = true;
-          nextHandler = null;
-        }
-      } else {
-        // check if all slides are shown in slider
-        if (this.props.slideCount <= this.props.slidesToShow ||
-          this.props.currentSlide >= (this.props.slideCount - this.props.slidesToShow)) {
-          nextClasses['slick-disabled'] = true;
-          nextHandler = null;
-        }
-      }
+    if (!Helpers.canGoNext(this.props)) {
+      nextClasses['slick-disabled'] = true;
+      nextHandler = null;
     }
-
 
     var nextArrowProps = {
       key: '1',

--- a/src/mixins/helpers.js
+++ b/src/mixins/helpers.js
@@ -103,6 +103,24 @@ var helpers = {
       }
     }
   },
+  canGoNext: function (opts){
+    var canGo = true;
+    if (!opts.infinite) {
+      if (opts.centerMode) {
+        // check if current slide is last slide
+        if (opts.currentSlide >= (opts.slideCount - 1)) {
+          canGo = false;
+        }
+      } else {
+        // check if all slides are shown in slider
+        if (opts.slideCount <= opts.slidesToShow ||
+          opts.currentSlide >= (opts.slideCount - opts.slidesToShow)) {
+          canGo = false;
+        }
+      }
+    }
+    return canGo;
+  },
   slideHandler: function (index) {
     // Functionality of animateSlide and postSlide is merged into this function
     // console.log('slideHandler', index);
@@ -121,7 +139,7 @@ var helpers = {
       if(this.props.infinite === false &&
         (index < 0 || index >= this.state.slideCount)) {
         return;
-      } 
+      }
 
       //  Shifting targetSlide back into the range
       if (index < 0) {
@@ -290,21 +308,32 @@ var helpers = {
 
     return 'vertical';
   },
+  play: function(){
+    var nextIndex;
+
+    if (!this.state.mounted) {
+      return false
+    }
+
+    if (this.props.rtl) {
+      nextIndex = this.state.currentSlide - this.props.slidesToScroll;
+    } else {
+      if (this.canGoNext(Object.assign({}, this.props,this.state))) {
+        nextIndex = this.state.currentSlide + this.props.slidesToScroll;
+      } else {
+        return false;
+      }
+    }
+
+    this.slideHandler(nextIndex);
+  },
   autoPlay: function () {
     if (this.state.autoPlayTimer) {
       return;
     }
-    var play = () => {
-      if (this.state.mounted) {
-        var nextIndex = this.props.rtl ?
-        this.state.currentSlide - this.props.slidesToScroll:
-        this.state.currentSlide + this.props.slidesToScroll;
-        this.slideHandler(nextIndex);
-      }
-    };
     if (this.props.autoplay) {
       this.setState({
-        autoPlayTimer: setInterval(play, this.props.autoplaySpeed)
+        autoPlayTimer: setInterval(this.play, this.props.autoplaySpeed)
       });
     }
   },


### PR DESCRIPTION
So far the carousel has had 2 shortfalls ignored by the maintainer:
- this bug where autoplay ignores the number of slides and shows an empty page. https://github.com/akiran/react-slick/issues/505
- responsive settings are not easily equipped to handle N number of slides centered when N is less than `slidesToShow` - https://github.com/akiran/react-slick/pull/494 (I did this PR instead of pulling all responsive logic outside the carousel, with more time and less priorities/scoping I would have done things different.
